### PR TITLE
refactor: use query invalidation

### DIFF
--- a/src/components/Forms/AddEventForm.tsx
+++ b/src/components/Forms/AddEventForm.tsx
@@ -31,7 +31,7 @@ import dayjs from 'dayjs'
 import { FaCloudUploadAlt, FaSave } from 'react-icons/fa'
 import { truncate } from 'lodash'
 import { Select } from 'chakra-react-select'
-import { IEvent, SubmitParams } from '../../types/interfaces'
+import { AddEventPayload, IEvent } from '../../types/interfaces'
 import { useCategories } from '../../hooks/useCategories'
 
 type FormValues = Omit<IEvent, 'active' | 'flyer' | 'categories'> & {
@@ -40,12 +40,9 @@ type FormValues = Omit<IEvent, 'active' | 'flyer' | 'categories'> & {
 }
 
 interface Props {
-  onSubmit: ({
-    payload,
-    image,
-    action
-  }: SubmitParams<Omit<IEvent, 'active' | 'flyer'>>) => void
+  onSubmit: (event: AddEventPayload) => void
   onClose: () => void
+  getImageUrl: (image: FileList) => Promise<string>
 }
 
 const schema = object({
@@ -68,7 +65,7 @@ const schema = object({
   })))
 })
 
-const AddEventForm = ({ onClose, onSubmit }: Props) => {
+const AddEventForm = ({ onClose, onSubmit, getImageUrl }: Props) => {
   const {
     register,
     handleSubmit,
@@ -85,13 +82,11 @@ const AddEventForm = ({ onClose, onSubmit }: Props) => {
 
   const submitHandler: SubmitHandler<FormValues> = async (data) => {
     const { flyer, categories: cats, ...rest } = data
+    const imgUrl = await getImageUrl(flyer)
     onSubmit({
-      payload: {
-        ...rest,
-        categories: cats.map(c => c.value)
-      },
-      image: flyer,
-      action: 'add'
+      ...rest,
+      categories: cats.map(cat => cat.value),
+      flyer: imgUrl
     })
     onClose()
   }

--- a/src/components/Forms/EditEventForm.tsx
+++ b/src/components/Forms/EditEventForm.tsx
@@ -31,21 +31,18 @@ import dayjs from 'dayjs'
 import { Select } from 'chakra-react-select'
 import { FaCloudUploadAlt, FaSave } from 'react-icons/fa'
 import { truncate } from 'lodash'
-import { IEvent, SubmitParams } from '../../types/interfaces'
+import { EditEventPayload, IEvent } from '../../types/interfaces'
 import { useCategories } from '../../hooks/useCategories'
 
-type FormValues = Omit<IEvent, 'active' | 'flyer' | 'categories'> & {
+type FormValues = Omit<IEvent, '_id' | 'active' | 'flyer' | 'categories'> & {
   flyer: FileList
   categories: { label: string, value: string }[]
 }
 
 interface Props {
-  onSubmit: ({
-    payload,
-    image,
-    action
-  }: SubmitParams<Omit<IEvent, 'active' | 'flyer' | 'categories'> & { categories: string[] }>) => void
+  onSubmit: (event: EditEventPayload) => void
   onClose: () => void
+  getImageUrl: (image: FileList) => Promise<string>
   event: IEvent
 }
 
@@ -69,7 +66,7 @@ const schema = object({
   })))
 })
 
-const EditEventForm = ({ event, onClose, onSubmit }: Props) => {
+const EditEventForm = ({ event, onClose, onSubmit, getImageUrl }: Props) => {
   const {
     title,
     description,
@@ -109,14 +106,12 @@ const EditEventForm = ({ event, onClose, onSubmit }: Props) => {
 
   const submitHandler: SubmitHandler<FormValues> = async (data) => {
     const { flyer, categories: newCategories, ...rest } = data
+    const imgUrl = await getImageUrl(flyer)
     onSubmit({
-      payload: {
-        ...rest,
-        _id: event._id,
-        categories: newCategories.map(category => category.value)
-      },
-      image: flyer,
-      action: 'edit'
+      ...rest,
+      _id: event._id,
+      categories: newCategories.map(category => category.value),
+      flyer: imgUrl
     })
     onClose()
   }

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -45,7 +45,7 @@ import {
   FaExternalLinkAlt
 } from 'react-icons/fa'
 import { useNavigate } from 'react-router-dom'
-import { truncate } from 'lodash'
+import { get, truncate } from 'lodash'
 import useEvents from '../hooks/useEvents'
 import { IEvent, ActionDef } from '../types/interfaces'
 import Table from '../components/Table/Table'
@@ -66,13 +66,15 @@ const Events = () => {
     page,
     maxPage,
     setPage,
+    addEvent,
+    updateEvent,
     deleteEvent,
     count,
-    eventSubmit,
     lowerShown,
     upperShown,
     sort,
-    toggleSort
+    toggleSort,
+    getImageUrl
   } = useEvents()
   const [modalContent, setModalContent] = useState<ReactElement | null>(null)
   const [modalTitle, setModalTitle] = useState('')
@@ -95,7 +97,8 @@ const Events = () => {
         <EditEventForm
           event={event}
           onClose={onModalClose}
-          onSubmit={eventSubmit}
+          onSubmit={updateEvent}
+          getImageUrl={getImageUrl}
         />
       )
       setModalTitle('Editar evento')
@@ -234,7 +237,8 @@ const Events = () => {
     setModalContent(
       <AddEventForm
         onClose={onModalClose}
-        onSubmit={eventSubmit}
+        onSubmit={addEvent}
+        getImageUrl={getImageUrl}
       />
     )
     onModalOpen()

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -35,6 +35,9 @@ export interface IEvent {
   readonly createdBy: IUser | string
 }
 
+export type AddEventPayload = Omit<IEvent, '_id' | 'createdBy'>
+export type EditEventPayload = AddEventPayload & { _id: string }
+
 export interface LoginResponse {
   token: string
 }

--- a/src/utils/func.ts
+++ b/src/utils/func.ts
@@ -1,4 +1,5 @@
 import qs from 'qs'
+import { crud } from '../services/crud.service'
 
 interface ParseQueryParamsParams {
   filters?: any
@@ -45,4 +46,21 @@ export const parseQueryParams = ({ filters, limit, skip, sort }: ParseQueryParam
     query.sort = sort
   }
   return qs.stringify(query)
+}
+
+export const getImageUrl = async (image: FileList, token: string) => {
+  if (image) {
+    const formData = new FormData()
+    formData.append('image', image[0])
+    const { data: imgUrl } = await crud<FormData, string>({
+      method: 'POST',
+      endpoint: 'upload/image',
+      payload: formData,
+      meta: {
+        token
+      }
+    })
+    return imgUrl
+  }
+  return ''
 }


### PR DESCRIPTION
Simplify mutations by using query invalidation instead of optimistic updates.

Closes #32 